### PR TITLE
Ci testshield cleanup

### DIFF
--- a/Production Design Projects/CITestShield/CITestShield.brd
+++ b/Production Design Projects/CITestShield/CITestShield.brd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.3.0">
+<eagle version="7.1.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -33,9 +33,9 @@
 <layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
 <layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="yes"/>
 <layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="26" name="bNames" color="7" fill="1" visible="no" active="yes"/>
-<layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
-<layer number="28" name="bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
 <layer number="30" name="bStop" color="7" fill="6" visible="no" active="yes"/>
 <layer number="31" name="tCream" color="7" fill="4" visible="no" active="yes"/>
@@ -97,8 +97,8 @@
 <layer number="118" name="Rect_Pads" color="7" fill="1" visible="no" active="no"/>
 <layer number="119" name="KAP_TEKEN" color="7" fill="1" visible="no" active="yes"/>
 <layer number="120" name="KAP_MAAT1" color="7" fill="1" visible="no" active="yes"/>
-<layer number="121" name="_tsilk" color="7" fill="1" visible="no" active="yes"/>
-<layer number="122" name="_bsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="121" name="_tsilk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="122" name="_bsilk" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="123" name="tTestmark" color="7" fill="1" visible="no" active="yes"/>
 <layer number="124" name="bTestmark" color="7" fill="1" visible="no" active="yes"/>
 <layer number="125" name="_tNames" color="7" fill="1" visible="yes" active="yes"/>
@@ -160,59 +160,9 @@
 </layers>
 <board>
 <plain>
-<text x="73.66" y="46.99" size="1.778" layer="121" font="vector">SPI</text>
 <text x="52.07" y="44.45" size="1.778" layer="121" font="vector">I2C</text>
-<text x="71.12" y="16.51" size="1.4224" layer="121" font="vector" rot="R90">Analog I/O</text>
-<text x="62.23" y="55.88" size="1.778" layer="121" font="vector">Digital In/Out</text>
-<text x="39.37" y="22.86" size="1.778" layer="121" font="vector">CI Test Shield
-v0.1.0
-mbed.org/cishield</text>
-<text x="87.63" y="41.91" size="1.778" layer="122" font="vector" rot="MR0">Tests
-Analog I/O - A0-5 mesh
-Digital I/O - D0-D9 loopback
-UART - D0/1 loopback
-SPI - micoSD W/R
-I2C - Flash / Temp Sensor
-PWM - Loopback
-Interrupt In - Loopback</text>
 <text x="50.8" y="31.75" size="1.016" layer="121" rot="R90">TMP102</text>
 <text x="54.61" y="39.37" size="1.016" layer="121" font="vector" rot="R90">Flash</text>
-<wire x1="69.85" y1="29.21" x2="86.36" y2="29.21" width="0.4064" layer="121"/>
-<wire x1="86.36" y1="29.21" x2="87.63" y2="27.94" width="0.4064" layer="121"/>
-<wire x1="87.63" y1="27.94" x2="87.63" y2="16.51" width="0.4064" layer="121"/>
-<wire x1="87.63" y1="16.51" x2="86.36" y2="15.24" width="0.4064" layer="121"/>
-<wire x1="86.36" y1="15.24" x2="69.85" y2="15.24" width="0.4064" layer="121"/>
-<wire x1="69.85" y1="15.24" x2="68.58" y2="16.51" width="0.4064" layer="121"/>
-<wire x1="68.58" y1="16.51" x2="68.58" y2="27.94" width="0.4064" layer="121"/>
-<wire x1="68.58" y1="27.94" x2="69.85" y2="29.21" width="0.4064" layer="121"/>
-<wire x1="60.96" y1="66.04" x2="86.36" y2="66.04" width="0.4064" layer="121"/>
-<wire x1="86.36" y1="66.04" x2="87.63" y2="64.77" width="0.4064" layer="121"/>
-<wire x1="87.63" y1="64.77" x2="87.63" y2="55.88" width="0.4064" layer="121"/>
-<wire x1="87.63" y1="55.88" x2="86.36" y2="54.61" width="0.4064" layer="121"/>
-<wire x1="86.36" y1="54.61" x2="60.96" y2="54.61" width="0.4064" layer="121"/>
-<wire x1="60.96" y1="54.61" x2="59.69" y2="55.88" width="0.4064" layer="121"/>
-<wire x1="59.69" y1="55.88" x2="59.69" y2="64.77" width="0.4064" layer="121"/>
-<wire x1="59.69" y1="64.77" x2="60.96" y2="66.04" width="0.4064" layer="121"/>
-<wire x1="87.63" y1="30.48" x2="69.85" y2="30.48" width="0.4064" layer="121"/>
-<wire x1="69.85" y1="30.48" x2="68.58" y2="31.75" width="0.4064" layer="121"/>
-<wire x1="68.58" y1="31.75" x2="68.58" y2="48.26" width="0.4064" layer="121"/>
-<wire x1="68.58" y1="48.26" x2="69.85" y2="49.53" width="0.4064" layer="121"/>
-<wire x1="69.85" y1="49.53" x2="87.63" y2="49.53" width="0.4064" layer="121"/>
-<wire x1="87.63" y1="49.53" x2="88.9" y2="48.26" width="0.4064" layer="121"/>
-<wire x1="88.9" y1="48.26" x2="88.9" y2="31.75" width="0.4064" layer="121"/>
-<wire x1="88.9" y1="31.75" x2="87.63" y2="30.48" width="0.4064" layer="121"/>
-<wire x1="41.91" y1="57.15" x2="53.34" y2="57.15" width="0.4064" layer="121"/>
-<wire x1="53.34" y1="57.15" x2="54.61" y2="55.88" width="0.4064" layer="121"/>
-<wire x1="54.61" y1="55.88" x2="54.61" y2="48.26" width="0.4064" layer="121"/>
-<wire x1="54.61" y1="48.26" x2="55.88" y2="46.99" width="0.4064" layer="121"/>
-<wire x1="55.88" y1="46.99" x2="63.5" y2="46.99" width="0.4064" layer="121"/>
-<wire x1="63.5" y1="46.99" x2="64.77" y2="45.72" width="0.4064" layer="121"/>
-<wire x1="64.77" y1="45.72" x2="64.77" y2="31.75" width="0.4064" layer="121"/>
-<wire x1="64.77" y1="31.75" x2="63.5" y2="30.48" width="0.4064" layer="121"/>
-<wire x1="63.5" y1="30.48" x2="41.91" y2="30.48" width="0.4064" layer="121"/>
-<wire x1="41.91" y1="30.48" x2="40.64" y2="31.75" width="0.4064" layer="121"/>
-<wire x1="40.64" y1="31.75" x2="40.64" y2="55.88" width="0.4064" layer="121"/>
-<wire x1="40.64" y1="55.88" x2="41.91" y2="57.15" width="0.4064" layer="121"/>
 <wire x1="13.97" y1="8.89" x2="22.86" y2="0" width="0" layer="20"/>
 <wire x1="22.86" y1="0" x2="64.77" y2="0" width="0" layer="20"/>
 <wire x1="64.77" y1="0" x2="67.31" y2="2.54" width="0" layer="20"/>
@@ -1091,10 +1041,4 @@ Allgemeine dseign Regeln, die die meisten Anwendungen passen. Bitte überprüfen
 </signals>
 </board>
 </drawing>
-<compatibility>
-<note version="6.3" minversion="6.2.2" severity="warning">
-Since Version 6.2.2 text objects can contain more than one line,
-which will not be processed correctly with this version.
-</note>
-</compatibility>
 </eagle>

--- a/Production Design Projects/CITestShield/CITestShieldBOM.csv
+++ b/Production Design Projects/CITestShield/CITestShieldBOM.csv
@@ -1,0 +1,11 @@
+"Qty";"Value";"Device";"Package";"Parts";"Description";"";
+"9";"0R";"R0603";"0603";"R7, R8, R9, R10, R13, R14, R15, R16, R17";"";"";
+"3";"100nF";"C0603";"0603";"C1, C2, C3";"Capacitor";"";
+"6";"10k";"R0603";"0603";"R1, R2, R3, R4, R5, R6";"";"";
+"2";"4k7";"R0603";"0603";"R11, R12";"";"";
+"1";"ARDUINO-R3_SILK";"ARDUINO-R3_SILK";"ARDUINO-R3-SILK";"BRD1";"";"";
+"1";"AT24LCXXXEIAJ";"AT24LCXXXEIAJ";"SO08-EIAJ";"EEPROM";"I2C EEPROM, 24LC family";"";
+"1";"LM75BD";"LM75BD";"SO8";"IC4";"";"";
+"1";"MICRO-SD";"MICRO-SD";"AMPHENOL-101-00660-68-6";"CON1";"";"";
+"1";"SPST-4_TP1154_J";"SPST-4_TP1154_J";"TP-1154X";"SW1";"";"";
+"11";"TEST-POINT-50R-SMD";"TEST-POINT-50R-SMD";"TP50-SMD";"TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11";"";"";


### PR DESCRIPTION
# Changes
1. remove obsolete hidden silkscreen layers from top and bottom that showed up on export to OSHPark
2. add BOM to make it easy to order parts
